### PR TITLE
replacing config and writer templates

### DIFF
--- a/lua/plugins/alpha.lua
+++ b/lua/plugins/alpha.lua
@@ -34,7 +34,7 @@ return
     -- stylua: ignore
     dashboard.section.buttons.val = {
       dashboard.button("f", " " .. " Find file",       "<cmd> Telescope find_files <cr>"),
-      dashboard.button("n", " " .. " New file",        "<cmd> ene <BAR> startinsert <cr>"),
+      dashboard.button("n", " " .. " New Writer File", "<cmd> NewWriterFile <cr>"),
       dashboard.button("r", " " .. " Recent files",    "<cmd> Telescope oldfiles <cr>"),
       dashboard.button("g", " " .. " Find text",       "<cmd> Telescope live_grep <cr>"),
       dashboard.button("l", "󰒲 " .. " Lazy",            "<cmd> Lazy <cr>"),

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,6 +1,17 @@
 return {
   { "folke/neoconf.nvim", cmd = "Neoconf" },
   "folke/neodev.nvim",
-  }
 
+  {
+    -- This tells lazy.nvim you're using a local plugin, not a GitHub repo
+    dir = "~/.config/nvim/lua/writer_templates",
+    name = "writer_templates",
+    lazy = false,
+
+    -- This tells it how to set it up
+    config = function()
+      require("writer_templates").setup()
+    end,
+  },
+}
 

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -1,6 +1,6 @@
 return {
 	"nvim-tree/nvim-tree.lua",
 	lazy = false,
-	config = {
+	opts = {
 	}
 }

--- a/lua/plugins/nvimorgmode.lua
+++ b/lua/plugins/nvimorgmode.lua
@@ -7,7 +7,7 @@ return
   event = 'VeryLazy',
   config = function()
     -- Load treesitter grammar for org
-    require('orgmode').setup_ts_grammar()
+    -- require('orgmode').setup_ts_grammar()
 
     -- Setup treesitter
     require('nvim-treesitter.configs').setup({
@@ -15,7 +15,7 @@ return
         enable = true,
         additional_vim_regex_highlighting = { 'org' },
       },
-      ensure_installed = { 'org' },
+     -- ensure_installed = { 'org' },
     })
 
     -- Setup orgmode

--- a/lua/plugins/styledoc.lua
+++ b/lua/plugins/styledoc.lua
@@ -7,7 +7,7 @@ dependencies = {
   "3rd/image.nvim",
  },
  opts = true,
- ft = "markdown",
+ ft = {},
 }
 
 

--- a/lua/plugins/vim-latex-preview.lua
+++ b/lua/plugins/vim-latex-preview.lua
@@ -1,3 +1,9 @@
 return {
-  { "xuhdev/vim-latex-live-preview" },
+	"xuhdev/vim-latex-live-preview",
+	ft = { "tex" }, -- Load only for LaTeX files
+	cmd = {"LLPStartPreview","LLPStopPreview","LLPTogglePreview"},
+	init = function()
+		vim.g.livepreview_previewer = "open -a Skim"
+		vim.g.livepreview_engine = "pdflatex" -- or "xelatex"
+	end,
 }

--- a/lua/plugins/whichkey.lua
+++ b/lua/plugins/whichkey.lua
@@ -1,4 +1,4 @@
 return {
-
+	lazy = false,
 	"folke/which-key.nvim",
 }

--- a/lua/writer_templates/init.lua
+++ b/lua/writer_templates/init.lua
@@ -1,0 +1,84 @@
+local M = {}
+
+-- Template definitions
+local templates = {
+    latex = {
+        name = "LaTeX Document",
+        content = [[
+\documentclass{article}
+\begin{document}
+\title{Your Title Here}
+\author{Yeo Zhi Zheng}
+\maketitle
+
+\section{Introduction}
+Your content here.
+
+\end{document}
+]]
+    },
+    markdown = {
+        name = "Markdown Document",
+        content = [[
+# Title
+
+## Introduction
+
+Your content here.
+]]
+    },
+    org = {
+        name = "Org-mode Document",
+        content = [[
+#+TITLE: Your Title Here
+#+AUTHOR: Yeo Zhi Zheng
+
+* Introduction
+Your content here.
+]]
+    }
+}
+
+-- Function to insert template content
+local function insert_template(template)
+    local lines = vim.split(template.content, "\n")
+    local bufnr = vim.api.nvim_get_current_buf()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    else
+        print("Error: Invalid buffer")
+    end
+end
+
+local M = {}
+
+-- Function to display template selection menu
+function M.select_template()
+    local items = {}
+    for _, template in pairs(templates) do
+        table.insert(items, template.name)
+    end
+
+    vim.ui.select(items, {
+        prompt = "Select a template:",
+    }, function(choice)
+        if choice then
+            for key, template in pairs(templates) do
+                if template.name == choice then
+                    vim.cmd('enew')
+                    insert_template(template)
+                    vim.bo.filetype = key
+                    break
+                end
+            end
+        end
+    end)
+end
+
+-- Create a command to invoke the template selection
+function M.setup()
+    vim.api.nvim_create_user_command("NewWriterFile", M.select_template, {})
+end
+
+return M
+


### PR DESCRIPTION
There were a few errors popping up, such as styledoc.nvim, writer_templates:
1. I have opted to remove "markdown" from styledoc's "ft", and 
2. moved writer_templates out to its own folder/directory under /.config.
3. For org, I commented out "ensure_installed" and require "orgmode" as the function seemed to be deprecated.
4. For vim-latex-preview, :LLPStartPreview was not being recognised as a pdfviewer hasn't been set yet. Added some code to set Skim as the default viewer so that the command can run.
5. Changed "nvim-tree" from config to opts.

Also made two quality of life changes:
1. auto-activated which-keys at launch to be more beginner-friendly.
2. Changed "New File" to "New Writer File" as I thought that the Writer Templates plugin was quite nice for a beginner to start with.